### PR TITLE
Configured tailwind color utilities and radial gradient

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -2,17 +2,46 @@ import { balthazar } from "./lib/fonts";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1>Hello World</h1>
-      <p className={`${balthazar.className}`}>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum."
-      </p>
+    <main className="flex min-h-screen flex-col items-center justify-between p-8 bg-green text-white">
+      <article className="bg-dark-green rounded-lg p-8">
+        <h1>Hello World</h1>
+        <p className={`${balthazar.className}`}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <div className="py-8 font-black">
+          <span className="rounded-l-lg p-2 bg-yellow-gradient">
+            Complete 3 Habits
+          </span>
+          <span className="rounded-r-lg p-2 bg-gradient-to-b from-blue to-dark-blue">
+            30XP
+          </span>
+        </div>
+        <span className="bg-neon-red rounded-full p-2">Physical</span>
+        <span className="bg-neon-blue rounded-full p-2">Mental</span>
+        <span className="bg-neon-green rounded-full p-2">Swift</span>
+      </article>
+      <article className="bg-blue p-8 rounded-lg">
+        <p className={`${balthazar.className}`}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </article>
+      <article className="bg-yellow p-8 rounded-lg">
+        <p className={`${balthazar.className}`}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </article>
     </main>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,23 @@ module.exports = {
         extrabold: 800,
         black: 900,
       },
+      colors: {
+        //primary color
+        "dark-green": "#0C1E1F",
+        green: "#153638",
+        // accent colors
+        yellow: "#CEA24F",
+        blue: "#39629B",
+        "dark-blue": "#1E4F96",
+        // task descriptor colors
+        "neon-red": "#F0432C",
+        "neon-blue": "#3384FC",
+        "neon-green": "#24AA49",
+      },
+      backgroundImage: {
+        "yellow-gradient":
+          "radial-gradient(ellipse, rgba(255,191,0,1) 0%, rgba(153,115,0,1) 100%)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Since tailwind does not have a utility for radial gradients, I added a property that allows us to apply a utility class `bg-yellow-gradient`.

Here's a screen shot of each of the colors on the page:

![image](https://github.com/HabitQuest/Habit-Quest/assets/44125370/3173f9ba-609f-4e35-8fb9-ebe2e6af1768)
